### PR TITLE
Investigate missing wata api key for payment

### DIFF
--- a/netlify/functions/wata-proxy.js
+++ b/netlify/functions/wata-proxy.js
@@ -190,7 +190,17 @@ exports.handler = async (event) => {
         success: true,
         paymentId,
         paymentUrl,
-        raw: data
+        raw: data,
+        debug: {
+          usedUrl: apiUrl,
+          usedHeaders: candidateHeaders[0],
+          envCheck: {
+            WATA_API_KEY: !!process.env.WATA_API_KEY,
+            WATA_CREATE_PAYMENT_URL: !!process.env.WATA_CREATE_PAYMENT_URL,
+            WATA_AUTH_HEADER: process.env.WATA_AUTH_HEADER,
+            WATA_AUTH_SCHEME: process.env.WATA_AUTH_SCHEME
+          }
+        }
       })
     };
   } catch (error) {


### PR DESCRIPTION
Add debug information to `wata-proxy` function response.

This helps diagnose persistent 401 errors by exposing the runtime environment variables and headers used by the function.

---
<a href="https://cursor.com/background-agent?bcId=bc-83ce2a1a-06e9-463c-9565-a57772b4d1d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-83ce2a1a-06e9-463c-9565-a57772b4d1d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

