### PR TITLE
Analyze wata transaction request

### DIFF
--- a/netlify/functions/wata-proxy.js
+++ b/netlify/functions/wata-proxy.js
@@ -85,15 +85,9 @@ exports.handler = async (event) => {
       };
     }
 
-    // Если URL не задан, пробуем стандартные эндпоинты из документации
+    // Если URL не задан, используем официальный эндпоинт Wata H2H links
     const defaultCandidates = [
-      'https://api.wata.pro/api/h2h/links',
-      'https://wata.pro/api/payments',
-      'https://wata.pro/api/payment',
-      'https://wata.pro/api/payment/create',
-      'https://wata.pro/api/payments/create',
-      'https://wata.pro/api/transactions',
-      'https://wata.pro/api/transactions/create'
+      'https://api.wata.pro/api/h2h/links'
     ];
     const candidateUrls = apiUrl ? [apiUrl] : defaultCandidates;
 


### PR DESCRIPTION
Update the default Wata API endpoint to `https://api.wata.pro/api/h2h/links` when no environment variables are configured.

---
<a href="https://cursor.com/background-agent?bcId=bc-e34e1c0a-ecca-4d59-b29c-785c81a3d082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e34e1c0a-ecca-4d59-b29c-785c81a3d082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

